### PR TITLE
fix:a bug of running CV

### DIFF
--- a/utils.R
+++ b/utils.R
@@ -1490,7 +1490,7 @@ conduct_likert_bayesian_analysis <- function(data,
     
     # 交叉验证评估 - 使用适合连续数据的损失函数
     cat("进行交叉验证...\n")
-    cv_result <- bnlearn::bn.cv(numeric_data, learned_net, loss = "logl-g", k = 10, debug = FALSE)
+    cv_result <- bnlearn::bn.cv(numeric_data, learned_net, loss = "logl", k = 10, debug = FALSE)
     cv_loss <- sapply(cv_result, function(x) x$loss)
     mean_cv_loss <- mean(cv_loss)
     sd_cv_loss <- sd(cv_loss)


### PR DESCRIPTION
我修复了贝叶斯分析的交叉验证中损失函数参数的错误。
我遵循前面的代码结构，只在此基础上做了最少修改。我截屏了修改前后软件的运行情况。
以下是我做的修改
1.我仅将交叉验证中的无效参数"logl-g"更正为bnlearn包认可的"logl"，确保交叉验证正常执行，不影响网络结构学习和Bootstrap分析等核心功能。utils.R


修改后的结果说明：
可以正常运行贝叶斯分析